### PR TITLE
delete boto3 requirement

### DIFF
--- a/STM_Services/STM_Analyse_Daily_Stops_Data/requirements.txt
+++ b/STM_Services/STM_Analyse_Daily_Stops_Data/requirements.txt
@@ -1,3 +1,2 @@
-boto3==1.28.77
 pandas==2.1.3
 pytz==2023.3.post1

--- a/STM_Services/STM_Create_Daily_Stops_Info/requirements.txt
+++ b/STM_Services/STM_Create_Daily_Stops_Info/requirements.txt
@@ -1,4 +1,3 @@
-boto3==1.28.77
 pandas==2.1.3
 fastparquet==2023.10.1
 pytz==2023.3.post1

--- a/STM_Services/STM_Fetch_GTFS_TripUpdates/requirements.txt
+++ b/STM_Services/STM_Fetch_GTFS_TripUpdates/requirements.txt
@@ -1,4 +1,3 @@
-boto3==1.28.77
 pandas==2.1.3
 fastparquet==2023.10.1
 gtfs-realtime-bindings==1.0.0

--- a/STM_Services/STM_Fetch_GTFS_VehiclePositions/requirements.txt
+++ b/STM_Services/STM_Fetch_GTFS_VehiclePositions/requirements.txt
@@ -1,4 +1,3 @@
-boto3==1.28.77
 pandas==2.1.3
 fastparquet==2023.10.1
 gtfs-realtime-bindings==1.0.0

--- a/STM_Services/STM_Fetch_Update_GTFS_Static_files/requirements.txt
+++ b/STM_Services/STM_Fetch_Update_GTFS_Static_files/requirements.txt
@@ -1,4 +1,3 @@
-boto3==1.28.77
 polars==0.19.17
 fastparquet==2023.10.1
 Requests==2.31.0

--- a/STM_Services/STM_Filter_Daily_GTFS_Static_files/requirements.txt
+++ b/STM_Services/STM_Filter_Daily_GTFS_Static_files/requirements.txt
@@ -1,4 +1,3 @@
-boto3==1.28.77
 polars==0.19.17
 fastparquet==2023.10.1
 numpy==1.26.0

--- a/STM_Services/STM_Merge_Daily_GTFS_VehiclePositions/requirements.txt
+++ b/STM_Services/STM_Merge_Daily_GTFS_VehiclePositions/requirements.txt
@@ -1,4 +1,3 @@
-boto3==1.28.77
 polars==0.19.19
 fastparquet==2023.10.1
 pytz==2023.3.post1


### PR DESCRIPTION
Nous n'avons pas besoin de Boto3 dans l'environnement AWS, ça va aider à réduire la taille des "packages"