### PR TITLE
Potential correction for deploy.yml

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -361,4 +361,3 @@ Outputs:
   BIXIFetchGBFSStationStatusTriggerArn:
     Description: "ARN of the EventBridge Rule for BIXIFetchGBFSStationStatus"
     Value: !GetAtt BIXIFetchGBFSStationStatusTrigger.Arn
-    

--- a/versioning.py
+++ b/versioning.py
@@ -1,26 +1,26 @@
-from subprocess import check_output,run, CalledProcessError
+from subprocess import check_output,call, CalledProcessError
 from json import loads, dump
 
 #Script that creates a new version of each function that has been modified after a deploy
 #and redirects the alias towards this new version
 def main():
     functions_dict={}
-    functions=loads(str(check_output('aws lambda list-functions --query "sort_by(Functions, &FunctionName)"'), "utf-8"))
+    functions=loads(str(check_output('aws lambda list-functions --query "sort_by(Functions, &FunctionName)"', shell=True), "latin-1"))
     #Iterates through all lambda functions to find their names, version and aliases
     for x in functions:
         name=x["FunctionName"]
-        alias=loads(str(check_output(f'aws lambda list-aliases --function-name {name}'), "latin-1"))["Aliases"]
+        alias=loads(str(check_output(f'aws lambda list-aliases --function-name {name}', shell=True), "latin-1"))["Aliases"]
         
         #Assuming we only have one alias per function and some don't (like serverless-api)
         if len(alias)>0:
             new=x["CodeSha256"]
-            current=loads(str(check_output(f'aws lambda get-function --function-name {alias[0]["AliasArn"]}'), "latin-1"))["Configuration"]["CodeSha256"]
+            current=loads(str(check_output(f'aws lambda get-function --function-name {alias[0]["AliasArn"]}', shell=True), "latin-1"))["Configuration"]["CodeSha256"]
             #AWS uses the Sha256 code to check if two versions differ so we do the same here
             if(new==current):
                 functions_dict[name.split("-")[2]]=0
             else:
                 try:
-                    run(f'aws lambda delete-alias --name {alias} --function-name {name}')
+                    call(f'aws lambda delete-alias --name {alias} --function-name {name}', shell=True)
                     functions_dict[name.split("-")[2]]=1
                 except CalledProcessError as e:
                     functions_dict[name.split("-")[2]]=0
@@ -30,4 +30,3 @@ def main():
                 
     with open("functions.json", "w") as outfile:
         dump(functions_dict, outfile)
-        


### PR DESCRIPTION
It worked on my terminal, but the pipeline terminal might need the "shell=True" parameter on to know that this is not a file

## Description

added the shell=True in all of the subprocess.call() and subprocess.check_output()
