### PR TITLE
Fix Daily stops info functions

### DIFF
--- a/STM_Services/STM_Analyse_Daily_Stops_Data/main.py
+++ b/STM_Services/STM_Analyse_Daily_Stops_Data/main.py
@@ -13,7 +13,7 @@ s3 = boto3.client('s3')
 
 def lambda_handler(event, context):
 
-    bucket_static_daily = event['daily_bucket_static']
+    bucket_static_daily = event['daily_static_bucket']
     bucket_vehicle_positions_daily_merge = event['bucket_vehicle_positions_daily_merge']
     output_bucket = event['output_bucket']
     timezone_str = event.get('timezone', 'America/Montreal')  # Default to 'America/Montreal' if not specified

--- a/template.yml
+++ b/template.yml
@@ -483,9 +483,9 @@ Resources:
           Id: "TargetFunction"
           Input: >-
             {
-              "static_bucket": "monitoring-mtl-gtfs-static",
               "daily_static_bucket": "monitoring-mtl-gtfs-static-daily",
-              "output_bucket": "monitoring-mtl-gtfs-daily-stops-infos",
+              "bucket_vehicle_positions_daily_merge": "monitoring-mtl-stm-gtfs-vehicle-positions-daily-merge",
+              "output_bucket": "monitoring-mtl-stm-analytics",
               "timezone": "America/Montreal"
             }
           
@@ -544,9 +544,9 @@ Resources:
           Id: "TargetFunction"
           Input: >-
             {
+              "static_bucket": "monitoring-mtl-gtfs-static",
               "daily_static_bucket": "monitoring-mtl-gtfs-static-daily",
-              "bucket_vehicle_positions_daily_merge": "monitoring-mtl-stm-gtfs-vehicle-positions-daily-merge",
-              "output_bucket": "monitoring-mtl-stm-analytics",
+              "output_bucket": "monitoring-mtl-gtfs-daily-stops-infos",
               "timezone": "America/Montreal"
             }
           


### PR DESCRIPTION
## Description

Fixes the alerts on the DailyStopsInfo functions

## Changes Made

- Reversed bucket names in the 2 DailyStopsInfo function's triggers
- Renamed a bucket key value in AnalyzeDailyStopsInfo so it matches with the one in CreateDailyStopsInfo

## Checklist

- [ x ] I have tested these changes locally.
- [ x ] I have included necessary documentation updates (if applicable).
- [ x ] My code follows the project's coding standards.
- [ x ] All existing tests are passing.
