### PR TITLE
Full fix CreateInfo and partial fix Analyze

### DIFF
--- a/STM_Services/STM_Analyse_Daily_Stops_Data/main.py
+++ b/STM_Services/STM_Analyse_Daily_Stops_Data/main.py
@@ -37,9 +37,9 @@ def lambda_handler(event, context):
     file_name_next_day = next_day.strftime('%Y-%m-%d')
 
     # Define the name of the local files
-    local_static_file_name = f'./tmp/filtered_stop_times_{file_name}.parquet'
-    local_file_name = f'./tmp/Daily_merge_{file_name}.parquet'
-    local_file_name_next_day = f'./tmp/Daily_merge_{file_name_next_day}.parquet'
+    local_static_file_name = f'/tmp/filtered_stop_times_{file_name}.parquet'
+    local_file_name = f'/tmp/Daily_merge_{file_name}.parquet'
+    local_file_name_next_day = f'/tmp/Daily_merge_{file_name_next_day}.parquet'
 
     # Define the folder and file structure on S3
     key_static = f'{folder_name}/filtered_stop_times/filtered_stop_times_{file_name}.parquet'
@@ -104,11 +104,11 @@ def lambda_handler(event, context):
                                 'vehicle_trip_routeId': 'routeId'})
     df_final = df_final.cast({'routeId': pl.Int64})
 
-    df_final.write_parquet(f'./tmp/data_stops_{file_name}.parquet')
+    df_final.write_parquet(f'/tmp/data_stops_{file_name}.parquet')
 
     # Upload the final file back to S3
     output_key = f'{folder_name}/data_stops_{file_name}.parquet'  # Set your output file path here
-    upload_file_from_tmp(f'./tmp/data_stops_{file_name}.parquet', output_bucket, output_key)
+    upload_file_from_tmp(f'/tmp/data_stops_{file_name}.parquet', output_bucket, output_key)
 
     clean_tmp_folder()
 
@@ -127,7 +127,7 @@ def download_file_to_tmp(bucket, key, local_file_name):
         s3.download_file(Bucket=bucket, Key=key, Filename=local_path)
         return local_path
     except Exception as e:
-        print(f'Error downloading file from S3: {e}')
+        print(f'Error downloading file from {bucket}/{key}: {e}')
         return False
 
 
@@ -153,7 +153,7 @@ def upload_file_from_tmp(local_file_name, bucket, key):
 
 
 def clean_tmp_folder():
-    tmp_dir = './tmp'
+    tmp_dir = '/tmp'
     for item in os.listdir(tmp_dir):
         item_path = os.path.join(tmp_dir, item)
         try:

--- a/STM_Services/STM_Create_Daily_Stops_Info/main.py
+++ b/STM_Services/STM_Create_Daily_Stops_Info/main.py
@@ -87,7 +87,7 @@ def lambda_handler(event, context):
 
     # Write and upload the DataFrame to S3
     output_file_path = f'{folder_name}/daily_stops_info/daily_stops_info_{file_name}.parquet'
-    local_output_path = f"./tmp/{os.path.basename(output_file_path)}"
+    local_output_path = f"/tmp/{os.path.basename(output_file_path)}"
     write_df_to_parquet_to_tmp(final_df, local_output_path)
     upload_file_from_tmp(output_bucket, output_file_path, local_output_path)
 
@@ -103,7 +103,7 @@ def lambda_handler(event, context):
     }
 
 def download_file_to_tmp(bucket, key):
-    local_path = f"./tmp/{os.path.basename(key)}"
+    local_path = f"/tmp/{os.path.basename(key)}"
     s3_client.download_file(Bucket=bucket, Key=key, Filename=local_path)
     return local_path
 

--- a/template.yml
+++ b/template.yml
@@ -28,7 +28,7 @@ Conditions:
   SetSTMAnalyzeDailyStopsData: !Not [!Equals [!Select [1, !Ref UpdateCheck], "0"]]
   SetSTMCreateDailyStopsInfo: !Not [!Equals [!Select [2, !Ref UpdateCheck], "0"]]
   SetSTMFetchGTFSTripUpdates: !Not [!Equals [!Select [3, !Ref UpdateCheck], "0"]]
-  SetSTMFetchGTFSVehiclePositions: !Not [!Equals [!Select [4, !Ref UpdateCheck], "0"]]
+  #SetSTMFetchGTFSVehiclePositions: !Not [!Equals [!Select [4, !Ref UpdateCheck], "0"]]
   SetSTMFetchUpdateGTFSStaticfiles: !Not [!Equals [!Select [5, !Ref UpdateCheck], "0"]]
   SetSTMFilterDailyGTFStaticfiles: !Not [!Equals [!Select [6, !Ref UpdateCheck], "0"]]
   SetSTMMergeDailyGTFSVechiclePositions: !Not [!Equals [!Select [7, !Ref UpdateCheck], "0"]]
@@ -650,7 +650,8 @@ Outputs:
   
   STMFetchGTFSVehiclePositionsUpdateStatus:
     Description: "Has STMFetchGTFSVehiclePositions been updated?"
-    Value: !If [SetSTMFetchGTFSVehiclePositions, "Yes", "No"]
+    Value: "Broken function working on older version until fixed"
+    #Value: !If [SetSTMFetchGTFSVehiclePositions, !Join [" ", ["Yes. It is now version:",!GetAtt STMFetchGTFSVehiclePositionsVersion.Version]], "No"]]
 
   STMFetchUpdateGTFSStaticfilesUpdateStatus:
     Description: "Has STMFetchUpdateGTFSStaticfiles been updated?"


### PR DESCRIPTION
## Description

Fix the following error in both DailyInfos function: [ERROR] OSError: [Errno 30] Read-only file system

## Changes Made

- Removed "." before each "/tmp/"
- Made an error message more relevant to read
- Added a temporary accurate output message for STMFetchVehiclePositions when deploying

## Checklist

- [ x ] I have tested these changes locally.
- [ x ] I have included necessary documentation updates (if applicable).
- [ x ] My code follows the project's coding standards.
- [ x ] All existing tests are passing.
