### PR TITLE
Add Mongo in BIXI_Fetch_GBFS_Station_Status

### DIFF
--- a/BIXI_Services/BIXI_Fetch_GBFS_Station_Status/main.py
+++ b/BIXI_Services/BIXI_Fetch_GBFS_Station_Status/main.py
@@ -6,11 +6,16 @@ import pytz
 import fastparquet
 from datetime import datetime
 from urllib.request import Request, urlopen
+from pymongo.mongo_client import MongoClient
+from pymongo.server_api import ServerApi
 
 # Set up S3 client
 s3 = boto3.client('s3')
 
 def lambda_handler(event, context):
+    atlas_uri = os.environ.get('ATLAS_URI')
+    db_name = os.environ.get('MONGO_DATABASE_NAME')
+    collection_name = event['collection_name']
     bucket_name = event['bucket_name']
     eastern = pytz.timezone('America/Toronto')
     now = datetime.now(eastern)
@@ -30,7 +35,8 @@ def lambda_handler(event, context):
     # Deserialize JSON data
     data_dict=json.loads(data)
     #Create dataframe with only the stations status
-    df = pd.DataFrame(data_dict["data"]["stations"])
+    stations = data_dict["data"]["stations"]
+    df = pd.DataFrame(stations)
 
     # Save Dataframe 
     temp_file_path = '/tmp/file.parquet'
@@ -52,6 +58,18 @@ def lambda_handler(event, context):
         except Exception as e:
             print(f"Failed to delete temporary file: {e}")
     
+
+    # Write to Mongo
+    mongoClient = MongoClient(atlas_uri, server_api=ServerApi('1'), tls=True, tlsAllowInvalidCertificates=True)
+    document_name = f'gbfs_data_station_status_{fetch_time_unix}'
+    try:
+        document = { "document_name": document_name, "stations": stations }
+        db = mongoClient[db_name]
+        collection = db[collection_name]
+        inserted = collection.insert_one(document)
+        print(f"inserted document with id: {inserted.inserted_id}")
+    except Exception as e:
+        print(f"Mongo insert returned an error: {e}")
 
 # You can set the environment variables 'API_URL' and 'bucket_name' accordingly.
 # Example usage: lambda_handler({'bucket_name': 'my-s3-bucket'}, None)

--- a/BIXI_Services/BIXI_Fetch_GBFS_Station_Status/requirements.txt
+++ b/BIXI_Services/BIXI_Fetch_GBFS_Station_Status/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.28.77
 pytz==2023.3.post1
 pandas==2.1.3
 fastparquet==2023.10.1
+pymongo==4.6.2

--- a/template.yml
+++ b/template.yml
@@ -317,6 +317,7 @@ Resources:
           Input: >-
             {
               "bucket_name": "monitoring-mtl-bixi-gtfs-station-status-dev",
+              "collection_name": "bixi-gtfs-station-status",
               "url": "https://gbfs.velobixi.com/gbfs/en/station_status.json"
             }
   
@@ -376,6 +377,7 @@ Resources:
           Input: >-
             {
               "bucket_name": "monitoring-mtl-gtfs-static",
+              "collection_name": "stm-gtfs-static"
               "url": "https://www.stm.info/sites/default/files/gtfs/gtfs_stm.zip"
             }
           


### PR DESCRIPTION
## Description

Adds the pymongo code to persist bixi station statuses
The database url and name are set in environment variables in the lmabda dashboard

## Changes Made

Station statuses are now saved both on S3 and mongodb

## Checklist

- [x] I have tested these changes locally.
- [x] I have included necessary documentation updates (if applicable).
- [x] My code follows the project's coding standards.
- [x] All existing tests are passing.
- [] I have added new tests (if new features or changes warrant them).
