### PR TITLE
Triggers adapted to UTC

### DIFF
--- a/.github/workflows/on-push-workflow.yml
+++ b/.github/workflows/on-push-workflow.yml
@@ -48,6 +48,7 @@ jobs:
           STMFetchUpdateStatic=$(jq -r '.STMFetchUpdateGTFSStaticfiles' functions.json)
           STMFilterDailyStatic=$(jq -r '.STMFilterDailyGTFStaticfiles' functions.json)
           STMMergeDailyVehiclePosition=$(jq -r '.STMMergeDailyGTFSVechiclePositions' functions.json)
+          today=$(date '+%Y-%m-%d')
           # Set environment variables
           echo "BIXI=$BIXI" >> $GITHUB_ENV
           echo "STMAnalyzeDailyStop=$STMAnalyzeDailyStop" >> $GITHUB_ENV
@@ -57,6 +58,7 @@ jobs:
           echo "STMFetchUpdateStatic=$STMFetchUpdateStatic" >> $GITHUB_ENV
           echo "STMFilterDailyStatic=$STMFilterDailyStatic" >> $GITHUB_ENV
           echo "STMMergeDailyVehiclePosition=$STMMergeDailyVehiclePosition" >> $GITHUB_ENV
+          echo "today=$today" >> $GITHUB_ENV
 
       - name: Build and Deploy to AWS
         env:
@@ -65,7 +67,7 @@ jobs:
           API_URL_STM_VEHICLE: ${{ secrets.API_URL_STM_VEHICLE }}
         run: |
           sam build
-          sam deploy --parameter-overrides ApiUrlStmTrip=$API_URL_STM_TRIP ApiKey=$API_KEY_STM ApiUrlStmVehicle=$API_URL_STM_VEHICLE UpdateCheck="${BIXI},${STMAnalyzeDailyStop},${STMCreateDailyStop},${STMFetchTripUpdates},${STMFetchVehiclePositions},${STMFetchUpdateStatic},${STMFilterDailyStatic},${STMMergeDailyVehiclePosition}"
+          sam deploy --parameter-overrides ApiUrlStmTrip=$API_URL_STM_TRIP ApiKey=$API_KEY_STM ApiUrlStmVehicle=$API_URL_STM_VEHICLE Date=$today UpdateCheck="${BIXI},${STMAnalyzeDailyStop},${STMCreateDailyStop},${STMFetchTripUpdates},${STMFetchVehiclePositions},${STMFetchUpdateStatic},${STMFilterDailyStatic},${STMMergeDailyVehiclePosition}"
 
       - name: Delete JSON File
         run: rm functions.json

--- a/STM_Services/STM_Create_Daily_Stops_Info/main.py
+++ b/STM_Services/STM_Create_Daily_Stops_Info/main.py
@@ -104,8 +104,12 @@ def lambda_handler(event, context):
 
 def download_file_to_tmp(bucket, key):
     local_path = f"/tmp/{os.path.basename(key)}"
-    s3_client.download_file(Bucket=bucket, Key=key, Filename=local_path)
-    return local_path
+    try:
+        s3_client.download_file(Bucket=bucket, Key=key, Filename=local_path)
+        return local_path
+    except Exception as e:
+        print(f'Error downloading file from {bucket}/{key}: {e}')
+        return False
 
 def upload_file_from_tmp(bucket, key, local_path):
     s3_client.upload_file(Filename=local_path, Bucket=bucket, Key=key)

--- a/STM_Services/STM_Merge_Daily_GTFS_VehiclePositions/main.py
+++ b/STM_Services/STM_Merge_Daily_GTFS_VehiclePositions/main.py
@@ -3,7 +3,7 @@ import os
 import io
 import polars as pl
 import concurrent.futures
-from datetime import datetime
+from datetime import datetime, timedelta
 import pytz
 
 # Initialize Boto3 S3 client
@@ -22,7 +22,9 @@ def lambda_handler(event, context):
     # Extract the date from the event, or use the current date in the specified timezone
     date_str = event.get('date', datetime.now(eastern).strftime('%Y%m%d'))
 
+    # Parse the date string into a datetime object
     date_obj = datetime.strptime(date_str, '%Y%m%d')
+    date_obj = date_obj - timedelta(days=1)
     formatted_date = date_obj.strftime('%Y-%m-%d')
 
     # We use "Bucket/YYYY/MM/DD/... as a folder structure to benefit from Partition since our query will be mainly with based on date

--- a/template.yml
+++ b/template.yml
@@ -374,8 +374,8 @@ Resources:
   STMFetchUpdateGTFSStaticfilesTrigger:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Calls STMFetchUpdateGTFSStaticfiles every morning at 6 AM (UTC)"
-      ScheduleExpression: cron(0 6 * * ? *)
+      Description: "Calls STMFetchUpdateGTFSStaticfiles every morning at 5:15 AM (UTC)"
+      ScheduleExpression: cron(15 5 * * ? *)
       State: ENABLED
       Targets:
         - Arn: !GetAtt STMFetchUpdateGTFSStaticfiles.Arn
@@ -434,8 +434,8 @@ Resources:
   STMFilterDailyGTFStaticfilesTrigger:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Calls STMFilterDailyGTFStaticfiles every morning at 8 AM (UTC)"
-      ScheduleExpression: cron(0 8 * * ? *)
+      Description: "Calls STMFilterDailyGTFStaticfiles every morning at 5:30 AM (UTC)"
+      ScheduleExpression: cron(30 5 * * ? *)
       State: ENABLED
       Targets:
         - Arn: !GetAtt STMFilterDailyGTFStaticfiles.Arn
@@ -495,8 +495,8 @@ Resources:
   STMAnalyzeDailyStopsDataTrigger:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Calls STMAnalyzeDailyStopsData every day at 0:15 AM (UTC)"
-      ScheduleExpression: cron(15 0 * * ? *)
+      Description: "Calls STMAnalyzeDailyStopsData every day at 6 AM (UTC)"
+      ScheduleExpression: cron(0 6 * * ? *)
       State: ENABLED
       Targets:
         - Arn: !GetAtt STMAnalyzeDailyStopsData.Arn
@@ -557,8 +557,8 @@ Resources:
   STMCreateDailyStopsInfoTrigger:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Calls STMCreateDailyStopsInfo every day at 1:15 AM (UTC)"
-      ScheduleExpression: cron(15 1 * * ? *)
+      Description: "Calls STMCreateDailyStopsInfo every day at 5:45 AM (UTC)"
+      ScheduleExpression: cron(45 5 * * ? *)
       State: ENABLED
       Targets:
         - Arn: !GetAtt STMCreateDailyStopsInfo.Arn
@@ -619,8 +619,8 @@ Resources:
   STMMergeDailyGTFSVechiclePositionsTrigger:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Calls STMMergeDailyGTFSVechiclePositions every day at 11:58 PM (UTC)"
-      ScheduleExpression: cron(58 23 * * ? *)
+      Description: "Calls STMMergeDailyGTFSVechiclePositions every day at 5:05 AM (UTC)"
+      ScheduleExpression: cron(5 5 * * ? *)
       State: ENABLED
       Targets:
         - Arn: !GetAtt STMMergeDailyGTFSVechiclePositions.Arn

--- a/template.yml
+++ b/template.yml
@@ -83,7 +83,7 @@ Resources:
   STMFetchGTFSTripUpdatesTrigger:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Calls STMFetchGTFSTripUpdates every 15 minute"
+      Description: "Calls STMFetchGTFSTripUpdates every 15 minutes"
       ScheduleExpression: rate(15 minutes)
       State: ENABLED
       Targets:
@@ -374,7 +374,7 @@ Resources:
   STMFetchUpdateGTFSStaticfilesTrigger:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Calls STMFetchUpdateGTFSStaticfiles every morning at 6 AM"
+      Description: "Calls STMFetchUpdateGTFSStaticfiles every morning at 6 AM (UTC)"
       ScheduleExpression: cron(0 6 * * ? *)
       State: ENABLED
       Targets:
@@ -434,7 +434,7 @@ Resources:
   STMFilterDailyGTFStaticfilesTrigger:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Calls STMFilterDailyGTFStaticfiles every morning at 8 AM"
+      Description: "Calls STMFilterDailyGTFStaticfiles every morning at 8 AM (UTC)"
       ScheduleExpression: cron(0 8 * * ? *)
       State: ENABLED
       Targets:
@@ -495,7 +495,7 @@ Resources:
   STMAnalyzeDailyStopsDataTrigger:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Calls STMAnalyzeDailyStopsData every day at 0:15 AM"
+      Description: "Calls STMAnalyzeDailyStopsData every day at 0:15 AM (UTC)"
       ScheduleExpression: cron(15 0 * * ? *)
       State: ENABLED
       Targets:
@@ -557,7 +557,7 @@ Resources:
   STMCreateDailyStopsInfoTrigger:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Calls STMCreateDailyStopsInfo every day at 1:15 AM"
+      Description: "Calls STMCreateDailyStopsInfo every day at 1:15 AM (UTC)"
       ScheduleExpression: cron(15 1 * * ? *)
       State: ENABLED
       Targets:
@@ -619,7 +619,7 @@ Resources:
   STMMergeDailyGTFSVechiclePositionsTrigger:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Calls STMMergeDailyGTFSVechiclePositions every day at 11:58 PM"
+      Description: "Calls STMMergeDailyGTFSVechiclePositions every day at 11:58 PM (UTC)"
       ScheduleExpression: cron(58 23 * * ? *)
       State: ENABLED
       Targets:

--- a/template.yml
+++ b/template.yml
@@ -15,6 +15,9 @@ Parameters:
   ApiUrlStmVehicle:
     Description: The STM API Vehicle URL
     Type: String
+  Date:
+    Description: Date of today for version history
+    Type: String
   UpdateCheck:
     Description: Checks if each function can be updated
     Type: CommaDelimitedList
@@ -64,6 +67,7 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
+      Description: !Ref Date
       FunctionName: !Ref STMFetchGTFSTripUpdates
 
   STMFetchGTFSTripUpdatesAlias:
@@ -124,6 +128,7 @@ Resources:
   #   DeletionPolicy: Retain
   #   UpdateReplacePolicy: Retain
   #   Properties:
+  #     Description: !Ref Date
   #     FunctionName: !Ref STMFetchGTFSVehiclePositions
 
   # STMFetchGTFSVehiclePositionsAlias:
@@ -293,6 +298,7 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
+      Description: !Ref Date
       FunctionName: !Ref BIXIFetchGBFSStationStatus
 
   BIXIFetchGBFSStationStatusAlias:
@@ -352,6 +358,7 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
+      Description: !Ref Date
       FunctionName: !Ref STMFetchUpdateGTFSStaticfiles
 
   STMFetchUpdateGTFSStaticfilesAlias:
@@ -411,6 +418,7 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
+      Description: !Ref Date
       FunctionName: !Ref STMFilterDailyGTFStaticfiles
 
   STMFilterDailyGTFStaticfilesAlias:
@@ -471,6 +479,7 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
+      Description: !Ref Date
       FunctionName: !Ref STMAnalyzeDailyStopsData
 
   STMAnalyzeDailyStopsDataAlias:
@@ -532,6 +541,7 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
+      Description: !Ref Date
       FunctionName: !Ref STMCreateDailyStopsInfo
 
   STMCreateDailyStopsInfoAlias:
@@ -593,6 +603,7 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
+      Description: !Ref Date
       FunctionName: !Ref STMMergeDailyGTFSVechiclePositions
 
   STMMergeDailyGTFSVechiclePositionsAlias:


### PR DESCRIPTION
## Description

I've realized that our triggers that are called using cron are in reality called according to the UTC timezone and not our local one.
I then had to move all of their schedule so they would run at the correct time for us and adapt some functions code for it to work properly.
This would have been a lot easier if we didn't have Daylight Saving Time here in Quebec because half the year we have a 5 hours difference with UTC and the other half is a 4 hour difference.

## Changes Made

- Changed execution hour of all functions that are called by cron
- STMMergeDailyGTFSVehiclePositions is now called in the early morning to merge the previous day. (DST made it impossible to keep it in the same day in a effective way)
- Improved error message when CreateDailyStopsInfo can't download from a bucket
- Added a new Date variable in the template so we can label the creation date of all our function versions

## Checklist

- [ x ] I have tested these changes locally.
- [ x ] I have included necessary documentation updates (if applicable).
- [ x ] My code follows the project's coding standards.
- [ x ] All existing tests are passing.
