### PR TITLE
#97: fix python version for bixi lambdas

### DIFF
--- a/BIXI_Services/BIXI_Historical_Data_Checker/requirements.txt
+++ b/BIXI_Services/BIXI_Historical_Data_Checker/requirements.txt
@@ -1,3 +1,3 @@
-pymongo[srv]
-beautifulsoup4
-requests
+pymongo==4.6.3
+beautifulsoup4==4.12.3
+requests==2.31.0

--- a/BIXI_Services/BIXI_Historical_Data_Processor/requirements.txt
+++ b/BIXI_Services/BIXI_Historical_Data_Processor/requirements.txt
@@ -1,4 +1,4 @@
-polars
-pymongo[srv]
-requests
-pydantic
+polars==0.20.19
+pymongo==4.6.3
+requests==2.31.0
+pydantic==2.7.0

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ bucket S3, dans un répertoire correspondant à la date de la journée.
 
 ### Prérequis
 
-- python3.11
+- python3.9
 - aws cli
 
 ### Installation

--- a/template.yml
+++ b/template.yml
@@ -377,7 +377,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: main.handler
-      Runtime: python3.11
+      Runtime: python3.9
       CodeUri: BIXI_Services/BIXI_Historical_Data_Checker/
       MemorySize: 128
       Timeout: 60
@@ -448,7 +448,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: main.handler
-      Runtime: python3.11
+      Runtime: python3.9
       CodeUri: BIXI_Services/BIXI_Historical_Data_Processor/
       MemorySize: 8192
       EphemeralStorage:


### PR DESCRIPTION
## Description

Fixing build and deploy failure due to python runtime version incompatibility

## Changes Made

- [x] change python version used for bixi historical data lambdas

## Related Issue

#97

## Checklist

- [x] I have tested these changes locally