### PR TITLE
#99: Fix Build and Deploy Fail Due to Missing Variables in `UpdateCheck`

### DIFF
--- a/.github/workflows/on-push-workflow.yml
+++ b/.github/workflows/on-push-workflow.yml
@@ -94,7 +94,7 @@ jobs:
             BixiLocationCollection=$BIXI_LOCATION_COLLECTION \
             BixiTripCollection=$BIXI_TRIP_COLLECTION \
             BixiChunkSize=$BIXI_CHUNK_SIZE \
-            UpdateCheck="${BIXI},${STMAnalyzeDailyStop},${STMCreateDailyStop},${STMFetchTripUpdates},${STMFetchVehiclePositions},${STMFetchUpdateStatic},${STMFilterDailyStatic},${STMMergeDailyVehiclePosition}"
+            UpdateCheck="${BIXI},${STMAnalyzeDailyStop},${STMCreateDailyStop},${STMFetchTripUpdates},${STMFetchVehiclePositions},${STMFetchUpdateStatic},${STMFilterDailyStatic},${STMMergeDailyVehiclePosition},${BixiHistoricDataChecker},${BixiHistoricDataProcessor}"
 
       - name: Delete JSON File
         run: rm functions.json

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -19,7 +19,7 @@ confirm_changeset = false
 resolve_s3 = true
 s3_prefix = "py-transit"
 region = "ca-central-1"
-parameter_overrides = "ApiKey=\"API_KEY_STM\" ApiUrlStmTrip=\"API_URL_STM_TRIP\" ApiUrlStmVehicle=\"API_URL_STM_VEHICLE\" UpdateCheck=\"[0,0,0,0,0,0,0,0]\""
+parameter_overrides = "ApiKey=\"API_KEY_STM\" ApiUrlStmTrip=\"API_URL_STM_TRIP\" ApiUrlStmVehicle=\"API_URL_STM_VEHICLE\" UpdateCheck=\"[0,0,0,0,0,0,0,0,0,0]\""
 image_repositories = []
 
 [default.package.parameters]


### PR DESCRIPTION
## Description

Fix for Build and Deploy Fail Due to Missing Variables in `UpdateCheck`. Probably was removed in a conflict resolution during a rebase.

## Changes Made

- [x] add missing variables in `UpdateCheck`

## Related Issue

#99

## Checklist

- [x] I have tested these changes locally.